### PR TITLE
Speed up top masks evaluation

### DIFF
--- a/InferDeepMask.lua
+++ b/InferDeepMask.lua
@@ -187,10 +187,11 @@ function Infer:getTopMasks(thr,h,w)
   local masks,topScores,np = self.mask,self.topScores,self.np
   topMasks:resize(np,h,w):zero()
   imgMask:resize(h,w)
-  local imgMaskPtr = imgMask:data()
+  imgMask:zero()
 
   for i = 1,np do
-    imgMask:zero()
+    local imgMask_copy = imgMask:clone()
+    local imgMaskPtr = imgMask_copy:data()
     local scale,x,y=topScores[i][2], topScores[i][3], topScores[i][4]
     local s=self.scales[scale]
     local sz = math.floor(self.iSz/s)
@@ -212,7 +213,7 @@ function Infer:getTopMasks(thr,h,w)
         end
       end
     end
-    topMasks:narrow(1,i,1):copy(imgMask)
+    topMasks:narrow(1,i,1):copy(imgMask_copy)
   end
 
   return topMasks

--- a/InferSharpMask.lua
+++ b/InferSharpMask.lua
@@ -282,10 +282,11 @@ function Infer:getTopMasks(thr,h,w)
   local topMasks0,topScores,np = self.topMasks0,self.topScores,self.np
   topMasks:resize(np,h,w):zero()
   imgMask:resize(h,w)
-  local imgMaskPtr = imgMask:data()
+  imgMask:zero()
 
   for i = 1,np do
-    imgMask:zero()
+    local imgMask_copy = imgMask:clone()
+    local imgMaskPtr = imgMask_copy:data()
     local scale,x,y = topScores[i][2],topScores[i][3],topScores[i][4]
     local s = self.scales[scale]
     local sz = math.floor(self.iSz/s)
@@ -306,7 +307,7 @@ function Infer:getTopMasks(thr,h,w)
       end
     end
 
-    topMasks:narrow(1,i,1):copy(imgMask)
+    topMasks:narrow(1,i,1):copy(imgMask_copy)
   end
 
   self.topMasks = topMasks


### PR DESCRIPTION
Top masks evaluation takes a long time for high number of proposals (e.g - 500) due to re-initialisation of imgMask in every loop